### PR TITLE
Add Dria retriever

### DIFF
--- a/docs/core_docs/docs/integrations/retrievers/dria.mdx
+++ b/docs/core_docs/docs/integrations/retrievers/dria.mdx
@@ -1,0 +1,33 @@
+---
+hide_table_of_contents: true
+---
+
+# Dria Retriever
+
+The [Dria](https://dria.co/profile) retriever allows an agent to perform a text-based search across a comprehensive knowledge hub.
+
+## Setup
+
+To use Dria retriever, you need to provide two things:
+
+- **API Key**: you can get yours at your [profile page](https://dria.co/profile) when you create an account.
+- **Contract ID**: accessible at the top of the page when viewing a knowledge or in its URL.
+  For example, the Bitcoin whitepaper is uploaded on Dria at https://dria.co/knowledge/2KxNbEb040GKQ1DSDNDsA-Fsj_BlQIEAlzBNuiapBR0, so its contract ID is `2KxNbEb040GKQ1DSDNDsA-Fsj_BlQIEAlzBNuiapBR0`.
+  Note that contract ID can be omitted during instantiation, and later be set via `dria.contractId = "your-contract"`
+
+Dria retriever exposes the underlying [Dria client](https://npmjs.com/package/dria) as well, refer to the [Dria documentation](https://github.com/firstbatchxyz/dria-js-client?tab=readme-ov-file#usage) to learn more about the client.
+
+## Usage
+
+import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
+
+<IntegrationInstallTooltip></IntegrationInstallTooltip>
+
+```bash npm2yarn
+npm install dria @langchain/community
+```
+
+import CodeBlock from "@theme/CodeBlock";
+import Example from "@examples/retrievers/dria.ts";
+
+<CodeBlock language="typescript">{Example}</CodeBlock>

--- a/docs/core_docs/docs/integrations/retrievers/dria.mdx
+++ b/docs/core_docs/docs/integrations/retrievers/dria.mdx
@@ -8,12 +8,18 @@ The [Dria](https://dria.co/profile) retriever allows an agent to perform a text-
 
 ## Setup
 
-To use Dria retriever, you need to provide two things:
+To use Dria retriever, first install Dria JS client:
+
+```bash npm2yarn
+npm install dria
+```
+
+You need to provide two things to the retriever:
 
 - **API Key**: you can get yours at your [profile page](https://dria.co/profile) when you create an account.
 - **Contract ID**: accessible at the top of the page when viewing a knowledge or in its URL.
   For example, the Bitcoin whitepaper is uploaded on Dria at https://dria.co/knowledge/2KxNbEb040GKQ1DSDNDsA-Fsj_BlQIEAlzBNuiapBR0, so its contract ID is `2KxNbEb040GKQ1DSDNDsA-Fsj_BlQIEAlzBNuiapBR0`.
-  Note that contract ID can be omitted during instantiation, and later be set via `dria.contractId = "your-contract"`
+  Contract ID can be omitted during instantiation, and later be set via `dria.contractId = "your-contract"`
 
 Dria retriever exposes the underlying [Dria client](https://npmjs.com/package/dria) as well, refer to the [Dria documentation](https://github.com/firstbatchxyz/dria-js-client?tab=readme-ov-file#usage) to learn more about the client.
 

--- a/examples/src/retrievers/dria.ts
+++ b/examples/src/retrievers/dria.ts
@@ -1,0 +1,14 @@
+import { DriaRetriever } from "@langchain/community/retrievers/dria";
+
+// contract of TypeScript Handbook v4.9 uploaded to Dria
+// https://dria.co/knowledge/-B64DjhUtCwBdXSpsRytlRQCu-bie-vSTvTIT8Ap3g0
+const contractId = "-B64DjhUtCwBdXSpsRytlRQCu-bie-vSTvTIT8Ap3g0";
+
+const retriever = new DriaRetriever({
+  contractId, // a knowledge to connect to
+  apiKey: "DRIA_API_KEY", // if not provided, will check env for `DRIA_API_KEY`
+  topK: 15, // optional: default value is 10
+});
+
+const docs = await retriever.getRelevantDocuments("What is a union type?");
+console.log(docs);

--- a/libs/langchain-community/.gitignore
+++ b/libs/langchain-community/.gitignore
@@ -506,6 +506,10 @@ retrievers/databerry.cjs
 retrievers/databerry.js
 retrievers/databerry.d.ts
 retrievers/databerry.d.cts
+retrievers/dria.cjs
+retrievers/dria.js
+retrievers/dria.d.ts
+retrievers/dria.d.cts
 retrievers/metal.cjs
 retrievers/metal.js
 retrievers/metal.d.ts

--- a/libs/langchain-community/langchain.config.js
+++ b/libs/langchain-community/langchain.config.js
@@ -9,9 +9,8 @@ function abs(relativePath) {
   return resolve(dirname(fileURLToPath(import.meta.url)), relativePath);
 }
 
-
 export const config = {
-  internals:[
+  internals: [
     /node\:/,
     /@langchain\/core\//,
     "convex",
@@ -161,6 +160,7 @@ export const config = {
     "retrievers/amazon_knowledge_base": "retrievers/amazon_knowledge_base",
     "retrievers/chaindesk": "retrievers/chaindesk",
     "retrievers/databerry": "retrievers/databerry",
+    "retrievers/dria": "retrievers/dria",
     "retrievers/metal": "retrievers/metal",
     "retrievers/remote": "retrievers/remote/index",
     "retrievers/supabase": "retrievers/supabase",
@@ -298,6 +298,7 @@ export const config = {
     "chat_models/iflytek_xinghuo/web",
     "retrievers/amazon_kendra",
     "retrievers/amazon_knowledge_base",
+    "retrievers/dria",
     "retrievers/metal",
     "retrievers/supabase",
     "retrievers/vectara_summary",
@@ -340,4 +341,4 @@ export const config = {
   cjsSource: "./dist-cjs",
   cjsDestination: "./dist",
   abs,
-}
+};

--- a/libs/langchain-community/package.json
+++ b/libs/langchain-community/package.json
@@ -1645,6 +1645,15 @@
       "import": "./retrievers/databerry.js",
       "require": "./retrievers/databerry.cjs"
     },
+    "./retrievers/dria": {
+      "types": {
+        "import": "./retrievers/dria.d.ts",
+        "require": "./retrievers/dria.d.cts",
+        "default": "./retrievers/dria.d.ts"
+      },
+      "import": "./retrievers/dria.js",
+      "require": "./retrievers/dria.cjs"
+    },
     "./retrievers/metal": {
       "types": {
         "import": "./retrievers/metal.d.ts",
@@ -2544,6 +2553,10 @@
     "retrievers/databerry.js",
     "retrievers/databerry.d.ts",
     "retrievers/databerry.d.cts",
+    "retrievers/dria.cjs",
+    "retrievers/dria.js",
+    "retrievers/dria.d.ts",
+    "retrievers/dria.d.cts",
     "retrievers/metal.cjs",
     "retrievers/metal.js",
     "retrievers/metal.d.ts",

--- a/libs/langchain-community/package.json
+++ b/libs/langchain-community/package.json
@@ -121,6 +121,7 @@
     "discord.js": "^14.14.1",
     "dotenv": "^16.0.3",
     "dpdm": "^3.12.0",
+    "dria": "^0.0.3",
     "eslint": "^8.33.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^8.6.0",
@@ -218,6 +219,7 @@
     "cohere-ai": "*",
     "convex": "^1.3.1",
     "discord.js": "^14.14.1",
+    "dria": "^0.0.3",
     "faiss-node": "^0.5.1",
     "firebase-admin": "^11.9.0",
     "google-auth-library": "^8.9.0",
@@ -403,6 +405,9 @@
       "optional": true
     },
     "discord.js": {
+      "optional": true
+    },
+    "dria": {
       "optional": true
     },
     "faiss-node": {

--- a/libs/langchain-community/src/retrievers/dria.ts
+++ b/libs/langchain-community/src/retrievers/dria.ts
@@ -1,0 +1,62 @@
+import {
+  BaseRetriever,
+  type BaseRetrieverInput,
+} from "@langchain/core/retrievers";
+import { Document } from "@langchain/core/documents";
+import {
+  AsyncCaller,
+  AsyncCallerParams,
+} from "@langchain/core/utils/async_caller";
+import { Dria, DriaParams } from "dria";
+import { getEnvironmentVariable } from "@langchain/core/utils/env";
+
+export interface DriaRetrieverArgs
+  extends DriaParams,
+    AsyncCallerParams,
+    BaseRetrieverInput {
+  topK?: number;
+  contractId: string;
+}
+
+export class DriaRetriever extends BaseRetriever {
+  static lc_name() {
+    return "DriaRetriever";
+  }
+
+  lc_namespace = ["langchain", "retrievers", "dria"];
+
+  get lc_secrets() {
+    return { apiKey: "DRIA_API_KEY" };
+  }
+
+  get lc_aliases() {
+    return { apiKey: "api_key" };
+  }
+
+  caller: AsyncCaller;
+
+  topK?: number;
+
+  apiKey: string;
+
+  driaClient: Dria;
+
+  constructor(fields: DriaRetrieverArgs) {
+    super(fields);
+    const { contractId, apiKey, topK, ...rest } = fields;
+
+    this.caller = new AsyncCaller(rest);
+    const API_KEY = apiKey ?? getEnvironmentVariable("DRIA_API_KEY");
+    if (!API_KEY) throw new Error("Missing DRIA_API_KEY.");
+    this.apiKey = API_KEY;
+    this.driaClient = new Dria({
+      apiKey: this.apiKey,
+      contractId,
+    });
+    this.topK = topK;
+  }
+
+  async _getRelevantDocuments(query: string): Promise<Document[]> {
+    return []; // TODO: implement
+  }
+}

--- a/libs/langchain-community/src/retrievers/dria.ts
+++ b/libs/langchain-community/src/retrievers/dria.ts
@@ -3,21 +3,41 @@ import {
   type BaseRetrieverInput,
 } from "@langchain/core/retrievers";
 import { Document } from "@langchain/core/documents";
-import {
-  AsyncCaller,
-  AsyncCallerParams,
-} from "@langchain/core/utils/async_caller";
-import { Dria, DriaParams } from "dria";
 import { getEnvironmentVariable } from "@langchain/core/utils/env";
+import type { DriaParams, SearchOptions as DriaSearchOptions } from "dria";
+import { Dria } from "dria";
 
+/**
+ * Configurations for Dria retriever.
+ *
+ * - `contractId`: a Dria knowledge's contract ID.
+ * - `apiKey`: a Dria API key; if omitted, the retriever will check for `DRIA_API_KEY` environment variable.
+ *
+ * The retrieval can be configured with the following options:
+ *
+ * - `topK`: number of results to return, max 20. (default: 10)
+ * - `rerank`: re-rank the results from most to least semantically relevant to the given search query. (default: true)
+ * - `level`: level of detail for the search, must be an integer from 0 to 5 (inclusive). (default: 1)
+ * - `field`: CSV field name, only relevant for the CSV files.
+ */
 export interface DriaRetrieverArgs
   extends DriaParams,
-    AsyncCallerParams,
-    BaseRetrieverInput {
-  topK?: number;
-  contractId: string;
-}
+    BaseRetrieverInput,
+    DriaSearchOptions {}
 
+/**
+ * Class for retrieving documents from knowledge uploaded to Dria.
+ *
+ * @example
+ * ```typescript
+ * // contract of TypeScript Handbook v4.9 uploaded to Dria
+ * const contractId = "-B64DjhUtCwBdXSpsRytlRQCu-bie-vSTvTIT8Ap3g0";
+ * const retriever = new DriaRetriever({ contractId });
+ *
+ * const docs = await retriever.getRelevantDocuments("What is a union type?");
+ * console.log(docs);
+ * ```
+ */
 export class DriaRetriever extends BaseRetriever {
   static lc_name() {
     return "DriaRetriever";
@@ -33,30 +53,70 @@ export class DriaRetriever extends BaseRetriever {
     return { apiKey: "api_key" };
   }
 
-  caller: AsyncCaller;
-
-  topK?: number;
-
   apiKey: string;
 
-  driaClient: Dria;
+  public driaClient: Dria;
+
+  private searchOptions: DriaSearchOptions;
 
   constructor(fields: DriaRetrieverArgs) {
     super(fields);
-    const { contractId, apiKey, topK, ...rest } = fields;
 
-    this.caller = new AsyncCaller(rest);
-    const API_KEY = apiKey ?? getEnvironmentVariable("DRIA_API_KEY");
-    if (!API_KEY) throw new Error("Missing DRIA_API_KEY.");
-    this.apiKey = API_KEY;
+    const apiKey = fields.apiKey ?? getEnvironmentVariable("DRIA_API_KEY");
+    if (!apiKey) throw new Error("Missing DRIA_API_KEY.");
+    this.apiKey = apiKey;
+
+    this.searchOptions = {
+      topK: fields.topK,
+      field: fields.field,
+      rerank: fields.rerank,
+      level: fields.level,
+    };
+
     this.driaClient = new Dria({
+      contractId: fields.contractId,
       apiKey: this.apiKey,
-      contractId,
     });
-    this.topK = topK;
   }
 
+  /**
+   * Currently connected knowledge on Dria.
+   *
+   * Retriever will use this contract ID while retrieving documents,
+   * and will throw an error if `undefined`.
+   *
+   * In the case that this is `undefined`, the user is expected to
+   * set contract ID manually, such as after creating a new knowledge & inserting
+   * data there with the Dria client.
+   */
+  get contractId(): string | undefined {
+    return this.driaClient.contractId;
+  }
+
+  set contractId(value: string) {
+    this.driaClient.contractId = value;
+  }
+
+  /**
+   * Retrieves documents from Dria with respect to the configured contract ID, based on
+   * the given query string.
+   *
+   * @param query The query string
+   * @returns  A promise that resolves to an array of documents, with page content as text,
+   * along with `id` and the relevance `score` within the metadata.
+   */
   async _getRelevantDocuments(query: string): Promise<Document[]> {
-    return []; // TODO: implement
+    const docs = await this.driaClient.search(query, this.searchOptions);
+    return docs.map(
+      (d) =>
+        new Document({
+          // dria.search returns a string within the metadata as the content
+          pageContent: d.metadata,
+          metadata: {
+            id: d.id,
+            score: d.score,
+          },
+        })
+    );
   }
 }

--- a/libs/langchain-community/src/retrievers/tests/dria.int.test.ts
+++ b/libs/langchain-community/src/retrievers/tests/dria.int.test.ts
@@ -1,0 +1,16 @@
+import { test, expect } from "@jest/globals";
+import { DriaRetriever } from "../dria.js";
+
+test.skip("DriaRetriever", async () => {
+  // contract of TypeScript Handbook v4.9 uploaded to Dria
+  // https://dria.co/knowledge/-B64DjhUtCwBdXSpsRytlRQCu-bie-vSTvTIT8Ap3g0
+  const contractId = "-B64DjhUtCwBdXSpsRytlRQCu-bie-vSTvTIT8Ap3g0";
+  const topK = 10;
+
+  const retriever = new DriaRetriever({ contractId, topK });
+
+  const docs = await retriever.getRelevantDocuments("What is a union type?");
+  expect(docs.length).toBe(topK);
+
+  console.log(docs[0].pageContent);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8932,6 +8932,7 @@ __metadata:
     discord.js: ^14.14.1
     dotenv: ^16.0.3
     dpdm: ^3.12.0
+    dria: ^0.0.3
     eslint: ^8.33.0
     eslint-config-airbnb-base: ^15.0.0
     eslint-config-prettier: ^8.6.0
@@ -9032,6 +9033,7 @@ __metadata:
     cohere-ai: "*"
     convex: ^1.3.1
     discord.js: ^14.14.1
+    dria: ^0.0.3
     faiss-node: ^0.5.1
     firebase-admin: ^11.9.0
     google-auth-library: ^8.9.0
@@ -9165,6 +9167,8 @@ __metadata:
     convex:
       optional: true
     discord.js:
+      optional: true
+    dria:
       optional: true
     faiss-node:
       optional: true
@@ -16246,6 +16250,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^1.6.5":
+  version: 1.6.7
+  resolution: "axios@npm:1.6.7"
+  dependencies:
+    follow-redirects: ^1.15.4
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: 87d4d429927d09942771f3b3a6c13580c183e31d7be0ee12f09be6d5655304996bb033d85e54be81606f4e89684df43be7bf52d14becb73a12727bf33298a082
+  languageName: node
+  linkType: hard
+
 "axobject-query@npm:^3.1.1, axobject-query@npm:^3.2.1":
   version: 3.2.1
   resolution: "axobject-query@npm:3.2.1"
@@ -19369,6 +19384,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dria@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "dria@npm:0.0.3"
+  dependencies:
+    axios: ^1.6.5
+    zod: ^3.22.4
+  checksum: 69d66479cb015e87425fba7f1741e4d895b4f43844e6b8897d3e7fe38e579097f2c4673d534141419d15a72866adf4db12acb9b59b42681ef2c4ee2d301b9267
+  languageName: node
+  linkType: hard
+
 "duck@npm:^0.1.12":
   version: 0.1.12
   resolution: "duck@npm:0.1.12"
@@ -21590,6 +21615,16 @@ __metadata:
     debug:
       optional: true
   checksum: faa66059b66358ba65c234c2f2a37fcec029dc22775f35d9ad6abac56003268baf41e55f9ee645957b32c7d9f62baf1f0b906e68267276f54ec4b4c597c2b190
+  languageName: node
+  linkType: hard
+
+"follow-redirects@npm:^1.15.4":
+  version: 1.15.5
+  resolution: "follow-redirects@npm:1.15.5"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: 5ca49b5ce6f44338cbfc3546823357e7a70813cecc9b7b768158a1d32c1e62e7407c944402a918ea8c38ae2e78266312d617dc68783fac502cbb55e1047b34ec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
[Dria](https://dria.co/) is a hub of public RAG models for developers to both contribute and utilize a shared embedding lake. This PR adds a retriever that can retrieve documents from Dria.